### PR TITLE
Install script refactoring to new school bash style

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,6 @@ Below are the logs of the script for reference.
 manishbansal8843@cloudshell:~/cloud-k8s-cluster (kubeadm-init)$ NUM_OF_NODES=2 GCP_PROJECT_NAME=kubeadm-init ./install.sh
 =====================================Welcome to cloud k8s cluster installer=====================================
 Usage: NUM_OF_NODES=3 CLOUD_PROVIDER=gcp GCP_PROJECT_NAME=project-name-value ./install.sh
-Cloud provider name is missing. Will deploy it on GCP by default.
 GCP_PROJECT_NAME value kubeadm-init will be used to create new k8s VM instances.
 Checking if project kubeadm-init exists or not
 kubeadm-init  kubeadm-init  859215342347

--- a/README.md
+++ b/README.md
@@ -14,14 +14,14 @@ https://medium.com/@manishbansal8843/automated-multi-node-kubernetes-installatio
 3. Clone this git repository in home directory.
 `cd ~ && git clone https://github.com/manishbansal8843/cloud-k8s-cluster.git && cd cloud-k8s-cluster`
 4. Execute install.sh script with following parameters.
-`./install.sh NUM_OF_NODES=3 GCP_PROJECT_NAME=kubeadm-init`
+`NUM_OF_NODES=3 GCP_PROJECT_NAME=kubeadm-init ./install.sh`
 5. Thats it. This will install a 3 node cluster on GCP with kubectl configured on master node.
 
 Below are the logs of the script for reference.
 ```
-manishbansal8843@cloudshell:~/cloud-k8s-cluster (kubeadm-init)$ ./install.sh NUM_OF_NODES=2 GCP_PROJECT_NAME=kubeadm-init
+manishbansal8843@cloudshell:~/cloud-k8s-cluster (kubeadm-init)$ NUM_OF_NODES=2 GCP_PROJECT_NAME=kubeadm-init ./install.sh
 =====================================Welcome to cloud k8s cluster installer=====================================
-Usage: ./install.sh NUM_OF_NODES=3 CLOUD_PROVIDER=gcp GCP_PROJECT_NAME=project-name-value
+Usage: NUM_OF_NODES=3 CLOUD_PROVIDER=gcp GCP_PROJECT_NAME=project-name-value ./install.sh
 Cloud provider name is missing. Will deploy it on GCP by default.
 GCP_PROJECT_NAME value kubeadm-init will be used to create new k8s VM instances.
 Checking if project kubeadm-init exists or not

--- a/install.sh
+++ b/install.sh
@@ -1,48 +1,19 @@
-#!/bin/bash
-set -e
+#!/bin/bash -e
+
 echo "=====================================Welcome to cloud k8s cluster installer====================================="
-echo "Usage: ./install.sh NUM_OF_NODES=3 CLOUD_PROVIDER=gcp GCP_PROJECT_NAME=project-name-value"
-SUPPORTED_CLOUD_PROVIDERS=("gcp")
-NUM_OF_NODES=3
-DEFAULT_CLOUD_PROVIDER="gcp"
-for ARGUMENT in "$@"
-do
+echo "Usage: NUM_OF_NODES=3 CLOUD_PROVIDER=gcp GCP_PROJECT_NAME=project-name-value ./install.sh"
 
-    KEY=$(echo $ARGUMENT | cut -f1 -d=)
-    VALUE=$(echo $ARGUMENT | cut -f2 -d=)   
-
-    case "$KEY" in
-            NUM_OF_NODES) NUM_OF_NODES=${VALUE} ;;
-            CLOUD_PROVIDER) CLOUD_PROVIDER=${VALUE} ;; 
-            GCP_PROJECT_NAME) GCP_PROJECT_NAME=${VALUE} ;;    
-            *)   
-    esac    
-
-
-done
-
-if [ $NUM_OF_NODES -lt 1 ]; then
-echo "NUM_OF_NODES cannot be less than 1"
-exit 1
-fi
-
+: ${NUM_OF_NODES:=3}
+: ${CLOUD_PROVIDER:="gcp"}
 WORKER_NODES=$(($NUM_OF_NODES - 1))
 
-if [ -z $CLOUD_PROVIDER ]
-then
-  CLOUD_PROVIDER=$DEFAULT_CLOUD_PROVIDER
-  echo "Cloud provider name is missing. Will deploy it on GCP by default."
-  . $CLOUD_PROVIDER/entrypoint.sh
-  exit 0
-else
-  for i in "${SUPPORTED_CLOUD_PROVIDERS[@]}"
-  do
-    if [ "$i" -eq "$CLOUD_PROVIDER" ]; then
-          echo "Going to install k8s cluster on $CLOUD_PROVIDER"
-          . $CLOUD_PROVIDER/entrypoint.sh
-          exit 0
-	  fi
-  done
-  echo "$CLOUD_PROVIDER cloud provider is not supported as of now. Kindly check documentation for supported cloud providers."
-  exit 1
+if [[ $NUM_OF_NODES -lt 1 ]]; then
+	echo "NUM_OF_NODES cannot be less than 1"
+	exit 1
+elif ! [[ -f $CLOUD_PROVIDER/entrypoint.sh ]]; then
+	echo "$CLOUD_PROVIDER cloud provider is not supported as of now. Kindly check documentation for supported cloud providers."
+	exit 2
 fi
+
+echo "Going to install k8s cluster on $CLOUD_PROVIDER"
+. $CLOUD_PROVIDER/entrypoint.sh


### PR DESCRIPTION
The refactored code does the same but in a new style bash, in less lines of code and a more clean structure. It also doesn't detect non `install.sh` related things like `GCP_PROJECT_NAME`. It is `gcp` package's responsible. The only difference is this version doesn't log `Cloud provider name is missing. Will deploy it on GCP by default.`

I also changed the parameter parsing because in a containerized world the environment variables are more preferable than custom solution flags. I can put your script into a container and can drive the behavior with env vars instead of editing the entrypoint or the command.